### PR TITLE
Add unit testing setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 *.pyc
+*.iml
 blacklists
 config
 lists
 logs
-oyster.iml
 oyster.log
 oyster_general.log
 scores

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python:
+    - "2.7"
+script:
+    python test/__init__.py

--- a/oyster.py
+++ b/oyster.py
@@ -891,5 +891,5 @@ if __name__ == '__main__':
             pass
         oy.loadPlaylist("default", skip=True)
 
-    while not oy.doExit:
+    while not oy.do_exit:
         oy.play(oy.filetoplay)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyhamcrest
+filemagic

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,21 @@
+__author__ = 'nabcos'
+
+import unittest
+
+def all_tests_suite():
+    suite = unittest.TestLoader().loadTestsFromNames([
+        'basic_tests'
+    ])
+    return unittest.TestSuite([suite])
+
+
+def main():
+    runner = unittest.TextTestRunner(verbosity=1 + sys.argv.count('-v'))
+    suite = all_tests_suite()
+    raise SystemExit(not runner.run(suite).wasSuccessful())
+
+if __name__ == '__main__':
+    import os
+    import sys
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    main()

--- a/test/basic_tests.py
+++ b/test/basic_tests.py
@@ -1,0 +1,52 @@
+__author__ = 'nabcos'
+
+import unittest
+from hamcrest import *
+import oyster
+import os
+import mock
+import oysterconfig
+import tempfile
+import shutil
+
+class BasicTests(unittest.TestCase):
+
+    test_dir = tempfile.mkdtemp()
+
+    def create_dummy_config_file(self):
+        """
+        FIXME: we're only able to mock config if this file exists
+        """
+        if not os.path.exists("config"):
+            os.mkdir("config")
+
+        config_file = file("config/default", 'w')
+        config_file.write("DUMMY")
+        config_file.close()
+
+    def setUp(self):
+        super(BasicTests, self).setUp()
+
+        self.create_dummy_config_file()
+
+        test_config = {"savedir": self.test_dir, "basedir": self.test_dir, "vol_get_cmd": "echo 1", "vol_filter_regexp": "(.)"}
+
+        oysterconfig.getConfig = mock.MagicMock(name="getConfig", return_value=test_config )
+        oyster.ControlThread = mock.MagicMock(name="ControlThread")
+        oyster.PlaylistBuilder = mock.MagicMock(name="PlaylistBuilder")
+
+        self.underTest = oyster.Oyster()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+        shutil.rmtree("config")
+        super( BasicTests, self ).tearDown( )
+
+    def testBasic(self):
+        assert_that(self.underTest, not_none())
+
+def main():
+    unittest.main()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
I want to be able to add unit tests while refactoring the backend code. This pull request changes the Oyster constructor and executable setup slightly to be able to instantiate an Oyster object without blocking or redirecting stdout/err.

This request depends on #21, because gstreamer module is not available on travis.
