### PR TITLE
Mark files in playlist editor

### DIFF
--- a/browse.py
+++ b/browse.py
@@ -245,7 +245,7 @@ def __directory_in_playlist(directory, playlist_contents):
         for name in walkfiles:
             filename, file_extension = os.path.splitext(name)
             if file_extension.lower()[1:] in filetypes:
-                if os.path.join(root, name).rstrip() + '\n' not in playlist_contents:
+                if os.path.join(root, name).rstrip() not in playlist_contents:
                     return False
 
     return True
@@ -306,7 +306,7 @@ for curfile in files:
         escapedfile = cgi.escape(curfile)
 
         if editplaylist:
-            if mediadir + dir + '\n' in playlistContents:
+            if mediadir + dir in playlistContents:
                 print "<td></td>"
             else:
                 print "<td><a class='" + cssfileclass + "' href=" + \

--- a/common.py
+++ b/common.py
@@ -398,7 +398,7 @@ def get_playlist_contents(playlist_name=None):
         playlist_file.close()
     playlist_path = myconfig['savedir'] + 'lists/' + playlist_name
     listfile = open(playlist_path)
-    playlist_contents = listfile.readlines()
+    playlist_contents = listfile.read().splitlines()
     listfile.close()
     return playlist_contents
 


### PR DESCRIPTION
Files or directories which are already parts of the playlist may no longer be added with the playlist editor. Directories are checked if their whole contents are part for the playlist, in order to allow easier recursive adding.
